### PR TITLE
Register outputs from role

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ rhsm_repositories:
 Note that globbing in repository names is supported.
 Use of `only` is mutually exclusive with the use of `enabled` and `disabled`, and the use of `only` takes precedence.
 
+Role Output
+-----------
+
+### oasis_role_rhsm
+
+The `oasis_role_rhsm` fact will be set by this role, containing the following outputs:
+
+- `repositories` - The complete list of subscribable repositories known to the system, as well as their enabled status.
+  This value will be `false` if the `rhsm_repositories` input var is not used.
+- `subscribed` - Whether or not the system is registered. (bool)
+- `subscribed_pool_ids` - A list of pool IDs current attached too the system. Will be an empty list if no pools or attached,
+  or if the system is not currently registered.
+
 Dependencies
 ------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,5 +18,7 @@
 
   - include_tasks: repo_endisable.yml
     when: "rhsm_repositories and 'only' not in rhsm_repositories"
+
+  - include_tasks: output.yml
   become: true
   become_user: root

--- a/tasks/output.yml
+++ b/tasks/output.yml
@@ -1,0 +1,19 @@
+- name: Get system subscription status
+  command: subscription-manager status
+  register: oasis_roles_rhsm_subscription
+  changed_when: false
+  failed_when: false
+
+- name: Get system subscribed pools
+  # This always exits 0 whether the system is subscribed or not;
+  # stdout is empty on an unsubbed system.
+  command: subscription-manager list --consumed --pool-only
+  register: oasis_roles_rhsm_pools
+  changed_when: false
+  failed_when: false
+
+- name: Register Role Output
+  set_fact:
+    oasis_roles_rhsm:
+      subscribed: "{{ oasis_roles_rhsm_subscription.rc == 0 }}"
+      subscribed_pool_ids: "{{ oasis_roles_rhsm_pools.stdout.split() }}"


### PR DESCRIPTION
This is effectively a work in progress, as we're not sure quite yet if we even want outputs from the OASIS roles, and haven't talked about what they should look like if we do, so consider this a PoC.