### PR TITLE
Add support for release handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,18 @@ Vars in this section directly correspond to the args available to the
 * `rhsm_consumer_name` - Name of the system to register (defaults to system hostname)
 * `rhsm_consumer_id` - Existing consumer ID to resume a previous registration
 * `rhsm_force_register` - Register the system even if it is already registered (bool, default false)
-* `rhsm_unregister` - Unregister a system if true (bool, default false, system will be unsubscribed before subscription is attempted)
+* `rhsm_unregister` - Unregister a system if true. The system will be unsubscribed before subscription is attempted
+  (bool, default false)
 
 ### Repository Management
 
+Note:
+> Using variables related to repository management may result in the role reporting a failure if the system is not registered.
+> Subscription tasks are run before repository management tasks to facilitate registration state before processing these variables.
+
+* `rhsm_release` - Set which operating system release version to use. Remember to quote this, since release versions tend to look like
+  floats to the YAML parser, e.g.  set the value to something like `"7.4"`, not `7.4`
+* `rhsm_release_unset` - Unset which operating system release version to use (bool, default false)
 * `rhsm_repositories` - Specifies which repositories to enable/disable, details below
 
 To enable/disable specific repositories:
@@ -85,6 +93,20 @@ rhsm_repositories:
 Note that globbing in repository names is supported.
 Use of `only` is mutually exclusive with the use of `enabled` and `disabled`, and the use of `only` takes precedence.
 
+To set a specific minor version of RHEL repositories to use:
+
+```yaml
+rhsm_release: "7.1"
+```
+
+To default to the latest available minor version of repositories:
+
+``yaml
+rhsm_release_unset: true
+```
+
+
+
 Role Output
 -----------
 
@@ -92,11 +114,11 @@ Role Output
 
 The `oasis_role_rhsm` fact will be set by this role, containing the following outputs:
 
-- `repositories` - The complete list of subscribable repositories known to the system, as well as their enabled status.
-  This value will be `false` if the `rhsm_repositories` input var is not used.
 - `subscribed` - Whether or not the system is registered. (bool)
-- `subscribed_pool_ids` - A list of pool IDs current attached too the system. Will be an empty list if no pools or attached,
+- `subscribed_pool_ids` - A list of pool IDs current attached to the system. Will be an empty list if no pools are attached,
   or if the system is not currently registered.
+- `release` - The current operating system release version being used by `subscription-manager`. Will be `null` if no specific
+  version is set, or if the system is not subscribed.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,6 +68,13 @@ rhsm_force_register: "{{ omit }}"
 # yes/no bool, default no
 rhsm_unregister: false
 
+# Bool, whether or not to unset the subscription-manager release,
+# run before the release is set
+rhsm_release_unset: false
+
+# Value to pass to subscription-manager release --set
+rhsm_release: null
+
 # a dict where keys are repository states, and values are a list of
 # repository names  to set to that state. Valid repository states are
 # "enabled", and "disabled". Additionally, the special "only" state can be

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,15 @@
   - include_tasks: subscribe.yml
     when: rhsm_username != omit or rhsm_activationkey != omit
 
+  # Release facts should always be gathered for inclusion in outputs
+  - include_tasks: release_fact.yml
+
+  # setting the release explodes if the system isn't subscribed,
+  # so it should go after the subscribe tasks, and should only
+  # run if changes to the release are requested.
+  - include_tasks: release.yml
+    when: rhsm_release or rhsm_release_unset
+
   - include_tasks: repo_only.yml
     when: "'only' in rhsm_repositories"
 

--- a/tasks/output.yml
+++ b/tasks/output.yml
@@ -17,3 +17,4 @@
     oasis_roles_rhsm:
       subscribed: "{{ oasis_roles_rhsm_subscription.rc == 0 }}"
       subscribed_pool_ids: "{{ oasis_roles_rhsm_pools.stdout.split() }}"
+      release: "{{ oasis_roles_rhsm_release }}"

--- a/tasks/release.yml
+++ b/tasks/release.yml
@@ -1,0 +1,15 @@
+# TODO These tasks should be considered for addition to the ansible
+#      rhsm_repositories module, which would remove the need to set facts to
+#      ensure idempotence when using the command module.
+- name: Unset subscription-manager release
+  command: subscription-manager release --unset
+  when: rhsm_release_unset and oasis_roles_rhsm_release
+  register: rhsm_release_unset_task
+
+- name: Set subscription-manager release
+  command: subscription-manager release --set {{ rhsm_release }}
+  when: rhsm_release and oasis_roles_rhsm_release != rhsm_release
+  register: rhsm_release_set_task
+
+# Set facts again after unsetting/setting s-m release
+- include_tasks: release_fact.yml

--- a/tasks/release_fact.yml
+++ b/tasks/release_fact.yml
@@ -1,0 +1,21 @@
+- name: Gather subscription-manager release information
+  command: subscription-manager release --show
+  register: rhsm_release_check
+  changed_when: false
+  failed_when: false
+
+- name: Set oasis_roles_rhsm_release fact to current value on system
+  set_fact:
+    # Expected string is "Release: <release>"
+    oasis_roles_rhsm_release: "{{ rhsm_release_check.stdout.split(': ')[1] }}"
+  when: '": " in rhsm_release_check.stdout'
+
+- name: Set oasis_roles_rhsm_release fact to null
+  set_fact:
+    oasis_roles_rhsm_release: null
+  # If the system is registered, output includes "not set"
+  # If the system is not registered, s-m exits with rc 1
+  # If there are additional conditions not accounted for here, the output task
+  # will fail due to oasis_roles_rhsm_release not being set. If this happens,
+  # you have found a bug. Please file it. :)
+  when: '"not set" in rhsm_release_check.stdout or rhsm_release_check.rc == 1'


### PR DESCRIPTION
Specifically, this adds support for the `--set` and `--unset` flags to
the `subscription-manager release` subcommand.

Closes #6