### PR TITLE
ansible 2.6 does not work with docker-py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ services:
 install:
   - pip install -U pip
   - pip --version
-  - pip install ansible ansible-lint yamllint flake8 molecule docker-py
+  # We want everything in requirements.txt except shade,
+  # since we only test docker in travis
+  - pip install $(grep -v shade < requirements.txt)
   - ansible-lint --version
   - yamllint --version
   - flake8 --version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible
 ansible-lint
-docker-py
+docker
 yamllint
 flake8
 molecule


### PR DESCRIPTION
Using docker library instead. They are the same library, but the pypi
name switched from "docker-py" to "docker" in 2.0:

https://docker-py.readthedocs.io/en/stable/change-log.html#breaking-changes

Ansible docs still refer to installing docker-py, so that's probably a
good docs fix opportunity?