### PR TITLE
Fix typos in the README.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Sean Myers <sean.myers@redhat.com>
+Greg Hellings <greg.hellings@gmail.com>

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ rhsm_release: "7.1"
 
 To default to the latest available minor version of repositories:
 
-``yaml
+```yaml
 rhsm_release_unset: true
 ```
 
@@ -110,7 +110,7 @@ rhsm_release_unset: true
 Role Output
 -----------
 
-### oasis_role_rhsm
+### oasis\_role\_rhsm
 
 The `oasis_role_rhsm` fact will be set by this role, containing the following outputs:
 


### PR DESCRIPTION
Missing tick before yaml caused the closing triple tick to invert the
status of escaped codeblocks throughout the rest of the file

The _ characters, therefore, were not registring as indicating an
underline