### PR TITLE
Support ansible 2.4 with vendored library

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = library/_rhsm_repository.py

--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ To default to the latest available minor version of repositories:
 rhsm_release_unset: true
 ```
 
-
-
 Role Output
 -----------
 
@@ -117,8 +115,13 @@ The `oasis_role_rhsm` fact will be set by this role, containing the following ou
 - `subscribed` - Whether or not the system is registered. (bool)
 - `subscribed_pool_ids` - A list of pool IDs current attached to the system. Will be an empty list if no pools are attached,
   or if the system is not currently registered.
+
+Deprecated:
+
 - `release` - The current operating system release version being used by `subscription-manager`. Will be `null` if no specific
   version is set, or if the system is not subscribed.
+
+The `release` output is deprecated and will be removed in the next release of `rhsm`.
 
 Dependencies
 ------------

--- a/library/_rhsm_repository.py
+++ b/library/_rhsm_repository.py
@@ -1,0 +1,230 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2017, Giovanni Sciortino (@giovannisciortino)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# This is a vendored version of rhsm_repository for use in ansible 2.4.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: rhsm_repository
+short_description: Manage RHSM repositories using the subscription-manager command
+description:
+  - Manage(Enable/Disable) RHSM repositories to the Red Hat Subscription
+    Management entitlement platform using the C(subscription-manager) command.
+version_added: '2.5'
+author: Giovanni Sciortino (@giovannisciortino)
+notes:
+  - In order to manage RHSM repositories the system must be already registered
+    to RHSM manually or using the Ansible C(redhat_subscription) module.
+
+requirements:
+  - subscription-manager
+options:
+  state:
+    description:
+      - If state is equal to present or disabled, indicates the desired
+        repository state.
+    choices: [present, enabled, absent, disabled]
+    required: True
+    default: "present"
+  name:
+    description:
+      - The ID of repositories to enable.
+      - To operate on several repositories this can accept a comma separated
+        list or a YAML list.
+    required: True
+'''
+
+EXAMPLES = '''
+- name: Enable a RHSM repository
+  rhsm_repository:
+    name: rhel-7-server-rpms
+
+- name: Disable all RHSM repositories
+  rhsm_repository:
+    name: '*'
+    state: disabled
+
+- name: Enable all repositories starting with rhel-6-server
+  rhsm_repository:
+    name: rhel-6-server*
+    state: enabled
+
+- name: Disable all repositories except rhel-7-server-rpms
+  rhsm_repository:
+    name: "{{ item }}"
+    state: disabled
+  with_items: "{{
+    rhsm_repository.repositories |
+    map(attribute='id') |
+    difference(['rhel-7-server-rpms']) }}"
+'''
+
+RETURN = '''
+repositories:
+  description:
+    - The list of RHSM repositories with their states.
+    - When this module is used to change the repositories states, this list contains the updated states after the changes.
+  returned: success
+  type: list
+'''
+
+import re
+import os
+from fnmatch import fnmatch
+from copy import deepcopy
+from ansible.module_utils.basic import AnsibleModule
+
+
+def run_subscription_manager(module, arguments):
+    # Execute subuscription-manager with arguments and manage common errors
+    rhsm_bin = module.get_bin_path('subscription-manager')
+    if not rhsm_bin:
+        module.fail_json(msg='The executable file subscription-manager was not found in PATH')
+
+    lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
+    rc, out, err = module.run_command("%s %s" % (rhsm_bin, " ".join(arguments)), environ_update=lang_env)
+
+    if rc == 1 and (err == 'The password you typed is invalid.\nPlease try again.\n' or os.getuid() != 0):
+        module.fail_json(msg='The executable file subscription-manager must be run using root privileges')
+    elif rc == 0 and out == 'This system has no repositories available through subscriptions.\n':
+        module.fail_json(msg='This system has no repositories available through subscriptions')
+    elif rc == 1:
+        module.fail_json(msg='subscription-manager failed with the following error: %s' % err)
+    else:
+        return rc, out, err
+
+
+def get_repository_list(module, list_parameter):
+    # Generate RHSM repository list and return a list of dict
+    if list_parameter == 'list_enabled':
+        rhsm_arguments = ['repos', '--list-enabled']
+    elif list_parameter == 'list_disabled':
+        rhsm_arguments = ['repos', '--list-disabled']
+    elif list_parameter == 'list':
+        rhsm_arguments = ['repos', '--list']
+    rc, out, err = run_subscription_manager(module, rhsm_arguments)
+
+    skip_lines = [
+        '+----------------------------------------------------------+',
+        '    Available Repositories in /etc/yum.repos.d/redhat.repo'
+    ]
+    repo_id_re_str = r'Repo ID:   (.*)'
+    repo_name_re_str = r'Repo Name: (.*)'
+    repo_url_re_str = r'Repo URL:  (.*)'
+    repo_enabled_re_str = r'Enabled:   (.*)'
+
+    repo_id = ''
+    repo_name = ''
+    repo_url = ''
+    repo_enabled = ''
+
+    repo_result = []
+
+    for line in out.split('\n'):
+        if line in skip_lines:
+            continue
+
+        repo_id_re = re.match(repo_id_re_str, line)
+        if repo_id_re:
+            repo_id = repo_id_re.group(1)
+            continue
+
+        repo_name_re = re.match(repo_name_re_str, line)
+        if repo_name_re:
+            repo_name = repo_name_re.group(1)
+            continue
+
+        repo_url_re = re.match(repo_url_re_str, line)
+        if repo_url_re:
+            repo_url = repo_url_re.group(1)
+            continue
+
+        repo_enabled_re = re.match(repo_enabled_re_str, line)
+        if repo_enabled_re:
+            repo_enabled = repo_enabled_re.group(1)
+
+        repo = {
+            "id": repo_id,
+            "name": repo_name,
+            "url": repo_url,
+            "enabled": True if repo_enabled == '1' else False
+        }
+        repo_result.append(repo)
+    return repo_result
+
+
+def repository_modify(module, state, name):
+    name = set(name)
+    current_repo_list = get_repository_list(module, 'list')
+    updated_repo_list = deepcopy(current_repo_list)
+    matched_existing_repo = {}
+    for repoid in name:
+        matched_existing_repo[repoid] = []
+        for idx, repo in enumerate(current_repo_list):
+            if fnmatch(repo['id'], repoid):
+                matched_existing_repo[repoid].append(repo)
+                # Update current_repo_list to return it as result variable
+                updated_repo_list[idx]['enabled'] = True if state == 'enabled' else False
+
+    changed = False
+    results = []
+    diff_before = ""
+    diff_after = ""
+    rhsm_arguments = ['repos']
+
+    for repoid in matched_existing_repo:
+        if len(matched_existing_repo[repoid]) == 0:
+            results.append("%s is not a valid repository ID" % repoid)
+            module.fail_json(results=results, msg="%s is not a valid repository ID" % repoid)
+        for repo in matched_existing_repo[repoid]:
+            if state in ['disabled', 'absent']:
+                if repo['enabled']:
+                    changed = True
+                    diff_before += "Repository '%s' is enabled for this system\n" % repo['id']
+                    diff_after += "Repository '%s' is disabled for this system\n" % repo['id']
+                results.append("Repository '%s' is disabled for this system" % repo['id'])
+                rhsm_arguments += ['--disable', repo['id']]
+            elif state in ['enabled', 'present']:
+                if not repo['enabled']:
+                    changed = True
+                    diff_before += "Repository '%s' is disabled for this system\n" % repo['id']
+                    diff_after += "Repository '%s' is enabled for this system\n" % repo['id']
+                results.append("Repository '%s' is enabled for this system" % repo['id'])
+                rhsm_arguments += ['--enable', repo['id']]
+
+    diff = {'before': diff_before,
+            'after': diff_after,
+            'before_header': "RHSM repositories",
+            'after_header': "RHSM repositories"}
+
+    if not module.check_mode:
+        rc, out, err = run_subscription_manager(module, rhsm_arguments)
+        results = out.split('\n')
+    module.exit_json(results=results, changed=changed, repositories=updated_repo_list, diff=diff)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type='list', required=True),
+            state=dict(choices=['enabled', 'disabled', 'present', 'absent'], default='enabled'),
+        ),
+        supports_check_mode=True,
+    )
+    name = module.params['name']
+    state = module.params['state']
+
+    repository_modify(module, state, name)
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,11 +22,19 @@
   - include_tasks: release.yml
     when: rhsm_release or rhsm_release_unset
 
+  # decide whether or not to use the vendored rhsm_repository module,
+  # which first appeared in ansible 2.5
+  - name: Determine if vendored rhsm_repository module should be used
+    set_fact:
+      _rhsm_repository_task: >-
+        {{ ansible_version.full is version_compare('2.5', '>=') |
+           ternary('rhsm_repository', '_rhsm_repository') }}
+
   - include_tasks: repo_only.yml
     when: "'only' in rhsm_repositories"
 
   - include_tasks: repo_endisable.yml
-    when: "rhsm_repositories and 'only' not in rhsm_repositories"
+    when: "'only' not in rhsm_repositories"
 
   - include_tasks: output.yml
   become: true

--- a/tasks/output.yml
+++ b/tasks/output.yml
@@ -18,3 +18,7 @@
       subscribed: "{{ oasis_roles_rhsm_subscription.rc == 0 }}"
       subscribed_pool_ids: "{{ oasis_roles_rhsm_pools.stdout.split() }}"
       release: "{{ oasis_roles_rhsm_release }}"
+
+      # Included here mainly for use by tests to ensure the version-based
+      # task module selection actually works in different versions of ansible.
+      _rhsm_repository_task: "{{ _rhsm_repository_task }}"

--- a/tasks/repo_endisable.yml
+++ b/tasks/repo_endisable.yml
@@ -1,11 +1,13 @@
 - name: Disable repositories
-  rhsm_repository:
+  action: "{{ _rhsm_repository_task }}"
+  args:
     state: disabled
     name: "{{ rhsm_repositories.disabled | default([]) }}"
   when: "'disabled' in rhsm_repositories"
 
 - name: Enable repositories
-  rhsm_repository:
+  action: "{{ _rhsm_repository_task }}"
+  args:
     state: enabled
     name: "{{ rhsm_repositories.enabled | default([]) }}"
   when: "'enabled' in rhsm_repositories"

--- a/tasks/repo_only.yml
+++ b/tasks/repo_only.yml
@@ -1,15 +1,15 @@
+# these tasks the idempotent equivalent of disabling all repos and then only
+# enabling specific ones, as seen in the rhsm_repository module docs.
 - name: Enable specific repositories
-  rhsm_repository:
+  action: "{{ _rhsm_repository_task }}"
+  args:
     state: enabled
     name: "{{ rhsm_repositories.only | default([]) }}"
   register: rhsm_repositories_enabled
 
-# this fun bit of data-mangling is the idempotent equivalent of
-# disabling all repos and then only enabling specific ones:
-# use the return value from the enable step and remove every
-# enabled repo not in the rhsm_repositories.only list.
 - name: Disable all other repositories
-  rhsm_repository:
+  action: "{{ _rhsm_repository_task }}"
+  args:
     state: disabled
     name: "{{ rhsm_repositories_enabled.repositories |
               map(attribute='id') |


### PR DESCRIPTION
The rhsm_repository module does not exist in 2.4. Given that the single
most common reason to subscribe a system is to get access to the CDN
repositories and related support, I think it makes sense to do this
rather than overcomplicate the requirements.

re #13 