### PR TITLE
Add a daily cron trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,5 @@ oasisMultistreamMoleculePipeline {
   upstream_git_url = 'https://github.com/oasis-roles/rhsm.git'
   molecule_role_name = 'rhsm'
   molecule_scenarios = ['basic_subscription', 'sub_unsub', 'release_set_unset']
+  properties = [pipelineTriggers([cron('H H * * *')])]
 }


### PR DESCRIPTION
There are a ton of different triggers that can give us cron-like
behavior. It's my hope that using this in conjunction with the github
branch folders mean we'll continue to get the current and desired
behavior from those jobs, and just get the daily cron trigger added on
top.

If this doesn't work, then we may end up having to effectively redeclare
the github branches config in every job. Hopefully this works. :)