### PR TITLE
Rename rhsm_repository_release to rhsm_release

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,4 @@
 # exclude modules vendored from ansible upstream
 exclude =
     library/_rhsm_repository.py
-    library/_rhsm_repository_release.py
+    library/_rhsm_release.py

--- a/library/_rhsm_release.py
+++ b/library/_rhsm_release.py
@@ -3,7 +3,7 @@
 # (c) 2018, Sean Myers <sean.myers@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This is a vendored version of rhsm_repository_release for use in ansible <2.8.
+# This is a vendored version of rhsm_release for use in ansible <2.8.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -16,7 +16,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: rhsm_repository_release
+module: rhsm_release
 short_description: Set or Unset RHSM Repository Release version
 version_added: '2.8'
 description:
@@ -39,17 +39,17 @@ author:
 EXAMPLES = '''
 # Set release version to 7.1
 - name: Set RHSM repository release version
-  rhsm_repository_release:
+  rhsm_release:
       release: "7.1"
 
 # Set release version to 6Server
 - name: Set RHSM repository release version
-  rhsm_repository_release:
+  rhsm_release:
       release: "6Server"
 
 # Unset release version
 - name: Unset RHSM repository release release
-  rhsm_repository_release:
+  rhsm_release:
       release: null
 '''
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,13 +13,13 @@
   - include_tasks: subscribe.yml
     when: rhsm_username != omit or rhsm_activationkey != omit
 
-  # decide whether or not to use the vendored rhsm_repository_release module,
+  # decide whether or not to use the vendored rhsm_release module,
   # which first appeared in ansible 2.8
-  - name: Determine if vendored rhsm_repository_release module should be used
+  - name: Determine if vendored rhsm_release module should be used
     set_fact:
-      _rhsm_repository_release_task: >-
+      _rhsm_release_task: >-
         {{ ansible_version.full is version_compare('2.8', '>=') |
-           ternary('rhsm_repository_release', '_rhsm_repository_release') }}
+           ternary('rhsm_release', '_rhsm_release') }}
 
   # setting the release explodes if the system isn't subscribed,
   # so it should go after the subscribe tasks, and should only

--- a/tasks/output.yml
+++ b/tasks/output.yml
@@ -21,4 +21,4 @@
       # Included here mainly for use by tests to ensure the version-based
       # task module selections actually work in different versions of ansible.
       _rhsm_repository_task: "{{ _rhsm_repository_task }}"
-      _rhsm_repository_release_task: "{{ _rhsm_repository_release_task }}"
+      _rhsm_release_task: "{{ _rhsm_release_task }}"

--- a/tasks/release.yml
+++ b/tasks/release.yml
@@ -2,13 +2,13 @@
 #      rhsm_repositories module, which would remove the need to set facts to
 #      ensure idempotence when using the command module.
 - name: Unset subscription-manager release
-  action: "{{ _rhsm_repository_release_task }}"
+  action: "{{ _rhsm_release_task }}"
   args:
     release: null
   when: rhsm_release_unset
 
 - name: Set subscription-manager release
-  action: "{{ _rhsm_repository_release_task }}"
+  action: "{{ _rhsm_release_task }}"
   args:
     release: "{{ rhsm_release }}"
   when: rhsm_release


### PR DESCRIPTION
This module was renamed in ansible prior to the 2.8 release. This
updates the role vendoring to adapt to the name change.