### PR TITLE
A whole mess of rhsm role updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Vars in this section directly correspond to the args available to the
 [redhat_subscription module](http://docs.ansible.com/ansible/latest/modules/redhat_subscription_module.html).
 
 * `rhsm_username` - access.redhat.com or Satellite (RHSM Provider) username
-* `rhsm_password` - access.redhat.com or Satellite (RHSM Provider) username
+* `rhsm_password` - access.redhat.com or Satellite (RHSM Provider) password
 * `rhsm_org_id` - RHSM Provider organization ID
 * `rhsm_activationkey` - RHSM Provider activation key
 * `rhsm_server_hostname` - hostname for alternate RHSM provider

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Vars in this section directly correspond to the args available to the
 * `rhsm_consumer_name` - Name of the system to register (defaults to system hostname)
 * `rhsm_consumer_id` - Existing consumer ID to resume a previous registration
 * `rhsm_force_register` - Register the system even if it is already registered (bool, default false)
-* `rhsm_unregister` - Unregister a system if true. The system will be unsubscribed before subscription is attempted
+* `rhsm_unregister` - Unregister a system if true. The system will be unregistered. System registration *will not be attempted*
   (bool, default false)
 
 ### Repository Management

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ rhsm_release_unset: true
 Role Output
 -----------
 
+> **DEPRECATION WARNING** Role outputs are deprecated, no longer supported, and will be removed
+> in a future version of this role.
+
 ### oasis\_role\_rhsm
 
 The `oasis_role_rhsm` fact will be set by this role, containing the following outputs:

--- a/molecule/basic_subscription/molecule.yml
+++ b/molecule/basic_subscription/molecule.yml
@@ -20,6 +20,7 @@ provisioner:
   playbooks:
     create: ../openstack/create.yml
     destroy: ../openstack/destroy.yml
+    prepare: ../shared/prepare.yml
   config_options:
     defaults:
       stdout_callback: yaml

--- a/molecule/release_set_unset/molecule.yml
+++ b/molecule/release_set_unset/molecule.yml
@@ -21,6 +21,7 @@ provisioner:
   playbooks:
     create: ../openstack/create.yml
     destroy: ../openstack/destroy.yml
+    prepare: ../shared/prepare.yml
   config_options:
     defaults:
       stdout_callback: yaml

--- a/molecule/shared/cleanup.yml
+++ b/molecule/shared/cleanup.yml
@@ -1,0 +1,19 @@
+- name: cleanup
+  gather_facts: false
+  hosts: rhsm
+  tasks:
+    - name: Check if host to clean up is available
+      wait_for_connection:
+        # connect_timeout defaults to 5 seconds, so setting
+        # timeout to less than that should give one connection attempt
+        timeout: 1
+      register: wait_result
+      ignore_errors: true
+
+    - name: Unregister system if available
+      include_role:
+        name: rhsm
+      vars:
+        rhsm_username: "{{ omit }}"
+        rhsm_unregister: true
+      when: wait_result is success

--- a/molecule/sub_unsub/molecule.yml
+++ b/molecule/sub_unsub/molecule.yml
@@ -20,6 +20,7 @@ provisioner:
   playbooks:
     create: ../openstack/create.yml
     destroy: ../openstack/destroy.yml
+    prepare: ../shared/prepare.yml
   config_options:
     defaults:
       stdout_callback: yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,5 @@
 # role tasks
 - block:
-  - name: Ensure subscription-manager is installed
-    package:
-      state: present
-      name: subscription-manager
-
   # Some of the tasks we run are scary-looking, even when skipped, so wrap the
   # various stages up in include_tasks and only show scary things when told to
   - include_tasks: unsubscribe.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,11 @@
   # Some of the tasks we run are scary-looking, even when skipped, so wrap the
   # various stages up in include_tasks and only show scary things when told to
   - include_tasks: unsubscribe.yml
-    when: rhsm_unregister
+  when: rhsm_unregister
+  become: true
+  become_user: root
 
+- block:
   - include_tasks: subscribe.yml
     when: rhsm_username != omit or rhsm_activationkey != omit
 
@@ -37,5 +40,6 @@
     when: "'only' not in rhsm_repositories"
 
   - include_tasks: output.yml
+  when: not rhsm_unregister
   become: true
   become_user: root


### PR DESCRIPTION
## Remove subscription-manager install task

Going through some subscription-manager docs and knowledge based articles, it's pretty clear that you need subscription-manager to be installed to be able to install subscription-manager, so this task is effectively redundant.

## Add outputs deprecation warning to readme

re #21 This adds the warning, but doesn't change any functionality.

## Fix incorrect rhsm_password readme description

`rhsm_password` description said it could be used to change the *username* used to register

## Redefine unsubscribe and subscribe behavior

closes #22 This addresses the questionable behavior of unregistering and re-registering in a single play call (it doesn't re-register anymore).

## Add subscription cleanup step to all scenarios

By far, the most registered systems that need to be cleaned out of our rhsm registrar are for this role's scenarios.